### PR TITLE
fixes negative r index over p array at initialize_phase_2 method

### DIFF
--- a/src/apcpp/primal_dual_ap_solver.cpp
+++ b/src/apcpp/primal_dual_ap_solver.cpp
@@ -229,7 +229,8 @@ void PrimalDualAPSolver::initialize_phase_2() {
 
                 // Note: The paper sets p[r] = k +1, but the FORTRAN code
                 //       sets p[r] = n. We use the latter as our standard.
-                p[r] = size;
+                if (r >= 0)
+                    p[r] = size;
             }
 
             if (!assign)


### PR DESCRIPTION
Hello, 

I was testing your code with a 1000x1000 matrix and I was getting a segmentation fault error.
So, I trace it back and I found that the r index at the PrimalDualAPSolver::initialize_phase_2 method was assuming negative values.
I fixed it as bellow and it seems to work properly now. :)
